### PR TITLE
logstash::params: use /usr as JAVA_HOME on redhat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 class logstash::params {
 
   $java_home = $::osfamily ? {
-    'RedHat' => '/usr/lib/jvm/jre-openjdk',
+    'RedHat' => '/usr',
     'Debian' => '/usr/lib/jvm/default-java',
   }
 


### PR DESCRIPTION
This uses the java executable in /usr/bin/java which is always present
whichever version of jdk / jre happens to be installed. Maybe it would
apply to Debian as well.
